### PR TITLE
Adjustment in the test_run_results model and adding new model

### DIFF
--- a/models/marts/fact_elementary_test_result_rows.yml
+++ b/models/marts/fact_elementary_test_result_rows.yml
@@ -1,0 +1,34 @@
+version: 2
+
+models:
+  - name: fact_elementary_test_result_rows
+    description: "Tabela fato de IDs de resultado de testes e sua contagem."
+    columns:
+      - name: 'test_run_result_row_sk'
+        description: "Chave primária substituta. Composta por: 'fact_test_results.model_execution_id', 'fact_test_results.elementary_test_results_id', 'dim_tests.test_sk', 'invocations.invocation_sk'e 'tests_result_row.test_result_row'."
+        tests:
+          - unique
+          - not_null
+          
+      - name: 'test_fk'
+        description: "Chave estrangeira. Composta por: test_sk."
+        tests:
+          - relationships:
+              to: ref('dim_elementary_tests')
+              field: test_sk
+    
+      - name: 'invocation_fk'
+        description: "Chave estrangeira. Composta por: invocation_sk."
+        tests:
+          - relationships:
+              to: ref('fact_elementary_invocations')
+              field: invocation_sk
+
+      - name: 'elementary_test_results_id'
+        description: "Coluna com o ID do resultado do teste."
+
+      - name: 'model_execution_id'
+        description: "Coluna com o ID do modelo de execução do teste."
+
+      - name: 'test_result_row'
+        description: "Coluna que identifica quantos testes foram executados."

--- a/models/staging/sources.yml
+++ b/models/staging/sources.yml
@@ -77,6 +77,9 @@ sources:
             tests:
               - unique
               - not_null
-              
+
       - name: dbt_utils_day
         description: "Tabela que contem dados das datas criadas a partir da macro do dbt_utils."
+
+      - name: "test_result_rows"
+        description: "Tabela com ID dos resultados dos testes e a contagem de testes."

--- a/models/staging/stg_elementary_test_result_rows.sql
+++ b/models/staging/stg_elementary_test_result_rows.sql
@@ -1,0 +1,10 @@
+with
+    renamed as (
+        select
+            elementary_test_results_id
+            , result_row as test_result_row
+            , {{ dbt_utils.dateadd('hour', -3, 'detected_at') }} as test_detected_at
+        from {{ source('raw_dbt_monitoring', 'test_result_rows') }}
+    )
+select *
+from renamed


### PR DESCRIPTION
**Overview**
This PR brings to adjust the join in the model "fact_elementary_test_run_results.sql" and create a new model for dbt moditoring based on the elementary metadata.

**Key changes**
- Correction in the join function in the "fact_elementary_test_run_results.sql" model to avoid duplication and exponential increase in table data
- Addition of the fact_elementary_test_results_rows sql model and yml. 