### PR TITLE
fix for releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,7 +39,7 @@ jobs:
         run: |
           BRANCH_NAME="${{ steps.getbranch.outputs.BRANCH }}"
           CURRENT_VERSION="${{ steps.gettag.outputs.TAG }}"
-          echo "The version is $CURRENT_VERSION"
+          CURRENT_VERSION="${CURRENT_VERSION#v}"  # Remove the 'v' from the start of the version
           IFS='.' read -ra VERSION_PARTS <<< "$CURRENT_VERSION"
           if [[ $BRANCH_NAME =~ ^feature/ ]]; then
             VERSION_PARTS[1]=$((VERSION_PARTS[1] + 1))
@@ -48,7 +48,7 @@ jobs:
           elif [[ $BRANCH_NAME =~ ^release/ ]]; then
             VERSION_PARTS[0]=$((VERSION_PARTS[0] + 1))
           fi
-          NEXT_VERSION="${VERSION_PARTS[0]}.${VERSION_PARTS[1]}.${VERSION_PARTS[2]}"
+          NEXT_VERSION="v${VERSION_PARTS[0]}.${VERSION_PARTS[1]}.${VERSION_PARTS[2]}"
           echo ::set-output name=NEXT_VERSION::"$NEXT_VERSION"
         
       - name: Create and publish new tag


### PR DESCRIPTION
There was a bug when publishing a release. It was getting the first term of VERSION_PARTS[0]=$((VERSION_PARTS[0] + 1)) as v1 instead of just 1, in the example v1.0.0.