### PR TITLE
CI enhancements

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,8 +31,7 @@ jobs:
       # ${{ github.ref }} was not giving v* as tag name, but refs/tags/v* instead, so I had to abbreviate it
       - name: Get latest abbreviated tag
         id: gettag
-        run: |
-          echo ::set-output name=TAG::$(git describe --tags --abbrev=0)
+        run: echo ::set-output name=TAG::$(git describe --tags $(git rev-list --tags --max-count=1)) # get the latest tag across all branches and put it in the output TAG
 
       - name: Calculate next version
         id: nextversion
@@ -41,12 +40,15 @@ jobs:
           CURRENT_VERSION="${{ steps.gettag.outputs.TAG }}"
           CURRENT_VERSION="${CURRENT_VERSION#v}"  # Remove the 'v' from the start of the version
           IFS='.' read -ra VERSION_PARTS <<< "$CURRENT_VERSION"
-          if [[ $BRANCH_NAME =~ ^feature/ ]]; then
+          if [[ $BRANCH_NAME =~ ^release/ ]]; then
+            VERSION_PARTS[0]=$((VERSION_PARTS[0] + 1))
+            VERSION_PARTS[1]=0
+            VERSION_PARTS[2]=0
+          elif [[ $BRANCH_NAME =~ ^feature/ ]]; then
             VERSION_PARTS[1]=$((VERSION_PARTS[1] + 1))
+            VERSION_PARTS[2]=0
           elif [[ $BRANCH_NAME =~ ^patch/ ]]; then
             VERSION_PARTS[2]=$((VERSION_PARTS[2] + 1))
-          elif [[ $BRANCH_NAME =~ ^release/ ]]; then
-            VERSION_PARTS[0]=$((VERSION_PARTS[0] + 1))
           fi
           NEXT_VERSION="v${VERSION_PARTS[0]}.${VERSION_PARTS[1]}.${VERSION_PARTS[2]}"
           echo ::set-output name=NEXT_VERSION::"$NEXT_VERSION"


### PR DESCRIPTION
### What
This PR adds enhancements in two parts of the CI, in the version calculation and how to get the tags across the branches.

### Why
In the old version of the CI, it was able to create new releases, functionalities and patches, but now it is able to pass from a patch version to a new release, or from a feature version to a release version.

Pratical examples:

how it used to work:
v0.0.30 -> v0.0.31 (new patch)
v1.0.0 -> v2.0.0 (new release)
v0.0.20 -> v0.1.20 (new feature)

With the enhancements it corrects the last behavior:
v0.0.20 -> v0.1.0 (a new feature, in this context, would be v0.1.0, not v0.1.20).

The way the code gets the latest tag changed to a better version, because existing code gets the latest tag in the branch. Now, the CI gets the latest tag across all branches (it diminishes the future chances of getting a bug).