### PR TITLE
test_result_rows dedup and dbt.dateadd function removed

### DIFF
--- a/models/marts/fact_elementary_test_run_results.sql
+++ b/models/marts/fact_elementary_test_run_results.sql
@@ -39,7 +39,7 @@ with
             elementary_test_results_id
             , test_id
             , invocation_id
-            , test_detected_at
+            , test_detected_date
             , test_type
             , test_status
             , test_failures
@@ -51,7 +51,7 @@ with
             , elementary_test_results.test_id
             , run_results.run_result_id
             , elementary_test_results.invocation_id as invocation_id
-            , elementary_test_results.test_detected_at
+            , elementary_test_results.test_detected_date
             , elementary_test_results.test_type
             , elementary_test_results.test_status
             , elementary_test_results.test_failures
@@ -86,7 +86,7 @@ with
             , fact_test_results.model_execution_id
             , dim_tests.test_sk as test_fk
             , invocations.invocation_sk as invocation_fk
-            , util_days.date_day as test_detected_at
+            , util_days.date_day as test_detected_date
             , fact_test_results.test_type
             , fact_test_results.test_status
             , fact_test_results.run_started_at
@@ -96,7 +96,7 @@ with
         from fact_test_results
         left join dim_tests on fact_test_results.test_id = dim_tests.test_id
         left join invocations on fact_test_results.invocation_id = invocations.invocation_id
-        left join util_days on fact_test_results.test_detected_at = util_days.date_day
+        left join util_days on fact_test_results.test_detected_date = util_days.date_day
     )
 select *
 from join_with_dim

--- a/models/marts/fact_elementary_test_run_results.yml
+++ b/models/marts/fact_elementary_test_run_results.yml
@@ -30,7 +30,7 @@ models:
       - name: 'model_execution_id'
         description: "Column with the ID of the model test execution."
 
-      - name: 'test_detected_at'
+      - name: 'test_detected_date'
         description: "Column with the timestamp of test detection."
         tests:
           - relationships:

--- a/models/staging/stg_elementary_dbt_invocations.sql
+++ b/models/staging/stg_elementary_dbt_invocations.sql
@@ -36,10 +36,10 @@ with
             , job_id
             , job_name
             , job_run_id
-            , {{ dbt.dateadd('hour', -3, 'run_started_at') }} as invocation_started_at
-            , {{ dbt.dateadd('hour', -3, 'run_completed_at') }} as invocation_completed_at
-            , {{ dbt.dateadd('hour', -3, 'run_started_at') }} as invocation_date
-            , {{ dbt.dateadd('hour', -3, 'generated_at') }} as invocation_generated_at
+            , run_started_at as invocation_started_at
+            , run_completed_at as invocation_completed_at
+            , cast(run_started_at as date) as invocation_date
+            , generated_at as invocation_generated_at
             , dbt_invocation_command
             , dbt_version
             , elementary_version

--- a/models/staging/stg_elementary_dbt_models.sql
+++ b/models/staging/stg_elementary_dbt_models.sql
@@ -44,7 +44,7 @@ with
             , table_type_mod
             , package_name
             , original_path
-            , {{ dbt.dateadd('hour', -3, 'generated_at') }}  as model_generated_at
+            , generated_at as model_generated_at
             , metadata_hash
         from renamed
     )

--- a/models/staging/stg_elementary_dbt_run_results.sql
+++ b/models/staging/stg_elementary_dbt_run_results.sql
@@ -28,17 +28,17 @@ with
             model_execution_id
             , run_result_id
             , invocation_id
-            , {{ dbt.dateadd('hour', -3, 'generated_at') }} as invocation_generated_at
+            , generated_at as invocation_generated_at
             , run_result_name
             , sql_statement
             , invocation_status
             , resource_type
             , execution_time
             , cast(generated_at as date) as run_date
-            , {{ dbt.dateadd('hour', -3, 'execute_started_at') }} as run_started_at
-            , {{ dbt.dateadd('hour', -3, 'execute_completed_at') }} as run_completed_at
-            , {{ dbt.dateadd('hour', -3, 'compile_started_at') }} as compile_started_at
-            , {{ dbt.dateadd('hour', -3, 'compile_completed_at') }} as compile_completed_at
+            , execute_started_at as run_started_at
+            , execute_completed_at as run_completed_at
+            , compile_started_at as compile_started_at
+            , compile_completed_at as compile_completed_at
             , rows_affected
             , query_id
             , is_full_refresh

--- a/models/staging/stg_elementary_dbt_source_freshness_results.sql
+++ b/models/staging/stg_elementary_dbt_source_freshness_results.sql
@@ -22,17 +22,17 @@ with
         select
             source_freshness_execution_id
             , source_freshness_id
-            , {{ dbt.dateadd('hour', -3, 'max_loaded_at') }} as source_max_loaded_at
-            , {{ dbt.dateadd('hour', -3, 'snapshotted_at') }} as source_snapshotted_at
-            , {{ dbt.dateadd('hour', -3, 'generated_at') }} as source_freshness_generated_at
+            , max_loaded_at as source_max_loaded_at
+            , snapshotted_at as source_snapshotted_at
+            , generated_at as source_freshness_generated_at
             , source_generate_date
             , source_max_loaded_at_seconds
             , source_status
             , source_error
-            , {{ dbt.dateadd('hour', -3, 'compile_started_at') }} as source_compile_started_at
-            , {{ dbt.dateadd('hour', -3, 'compile_completed_at') }} as source_compile_completed_at
-            , {{ dbt.dateadd('hour', -3, 'execute_started_at') }} as source_execute_started_at
-            , {{ dbt.dateadd('hour', -3, 'execute_completed_at') }} as source_execute_completed_at
+            , compile_started_at as source_compile_started_at
+            , compile_completed_at as source_compile_completed_at
+            , execute_started_at as source_execute_started_at
+            , execute_completed_at as source_execute_completed_at
             , invocation_id
         from renamed
     )

--- a/models/staging/stg_elementary_dbt_sources.sql
+++ b/models/staging/stg_elementary_dbt_sources.sql
@@ -36,7 +36,7 @@ with
             , dbt_source_path
             , source_description
             , source_table_description
-            , {{ dbt.dateadd('hour', -3, 'generated_at') }} as source_generated_at
+            , generated_at as source_generated_at
             , metadata_hash
         from renamed
     )

--- a/models/staging/stg_elementary_elementary_test_results.sql
+++ b/models/staging/stg_elementary_elementary_test_results.sql
@@ -7,7 +7,8 @@ with
             , test_unique_id as test_id
             , model_unique_id as model_id
             , invocation_id
-            , {{ dbt.dateadd('hour', -3, 'detected_at') }} as test_detected_at
+            , detected_at as test_detected_at
+            , cast(detected_at as date) as test_detected_date
             , database_name as project_database_name
             , schema_name
             , table_name

--- a/models/staging/stg_elementary_test_result_rows.sql
+++ b/models/staging/stg_elementary_test_result_rows.sql
@@ -3,7 +3,8 @@ with
         select
             elementary_test_results_id
             , result_row as test_result_row
-            , {{ dbt.dateadd('hour', -3, 'detected_at') }} as test_detected_at
+            , detected_at as test_detected_at
+            , cast(detected_at as date) as test_detected_date
         from {{ source('raw_dbt_monitoring', 'test_result_rows') }}
     )
 


### PR DESCRIPTION
### Overview

This PR proposes exclude the dbt.dateadd function since this was beeing used to transform the timestamp columns to brazilian timezone through dbt. Also, a few timestamp columns needed to use cast to date so it could join with dbt_ultis date_day. And,  as the `test_result_rows` table can generate duplicated `test_run_result_row_sk` for `fact_elementary_test_result_rows`, the row_number window function was added to dedup and fix this problem.

### Key changes

- dbt.dateadd removed;
- timestamp columns that joins with dbt_utils date_day cast to date;
- `test_result_rows` CTE dedup in `fact_elementary_test_result_rows;
`
### Other notes

N/A

### Related links

### Checklist
_The following items are not covered by automated testing._
- [N/A] All added/modified models and columns are documented and tested in `schema.yml` files.
- [x] All tests pass. **OR**    
    _Check one:_
    - [ ] There are no new test failures, whether or not the existing model was intentionally changed for this PR.
    - [ ] This PR causes new test failures and there is a plan in place for addressing them.