### PR TITLE
Feature: adds a dedup to dbt_models, dbt_sources and dbt_tests stagings

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,23 @@ Or to CMD (Windows):
 
 `set ELEMENTARY_SOURCE_SCHEMA=elementary`
 
+## Deduplication of staging models
+
+We identify an issue involving duplication of IDs in some models. These staging models feed into dimension models, and the duplicates were causing inconsistencies in the data pipeline.
+
+The duplication of IDs in the staging models was propagating to both dimension and fact models, leading to potential inaccuracies in downstream processes. These duplications can negatively impact various use cases of this package, such as data analysis, reporting, and dashboards in data visualization tools, resulting in misleading insights.
+
+So, in the last update of this package, we've added a step to deduplicate this models. The deduplication is based on the ID and the generated_at timestamp. The following SQL criterion was applied:
+
+```sql
+
+qualify row_number() over (
+    partition by model_id -- source_id or test_id
+    order by generated_at desc
+) = 1
+
+```
+
 ## New releases
 
 Want a new release (major/minor/patch) ?

--- a/models/staging/stg_elementary_dbt_models.sql
+++ b/models/staging/stg_elementary_dbt_models.sql
@@ -1,6 +1,6 @@
 with
     renamed as (
-        select distinct
+        select
             unique_id as model_id
             , checksum
             , materialization
@@ -26,10 +26,14 @@ with
             , cast(generated_at as timestamp) as generated_at
             , metadata_hash
         from {{ source('raw_dbt_monitoring', 'dbt_models') }}
+        qualify row_number() over(
+            partition by model_id
+            order by generated_at desc
+        ) = 1
     )
 
     , dbt_dateadd as (
-        select distinct
+        select
             model_id
             , checksum
             , materialization

--- a/models/staging/stg_elementary_dbt_sources.sql
+++ b/models/staging/stg_elementary_dbt_sources.sql
@@ -1,6 +1,6 @@
 with
     renamed as (
-        select distinct
+        select
             unique_id as source_id
             , database_name as project_database_name
             , schema_name
@@ -18,10 +18,14 @@ with
             , cast(generated_at as timestamp) generated_at
             , metadata_hash
         from {{ source('raw_dbt_monitoring', 'dbt_sources') }}
+        qualify row_number() over(
+            partition by source_id
+            order by generated_at desc
+        ) = 1
     )
 
     , dbt_dateadd as (
-        select distinct
+        select
             source_id
             , project_database_name
             , schema_name

--- a/models/staging/stg_elementary_dbt_tests.sql
+++ b/models/staging/stg_elementary_dbt_tests.sql
@@ -1,6 +1,6 @@
 with
     source as (
-        select distinct
+        select
             unique_id as test_id
             , database_name as project_database_name
             , schema_name
@@ -34,6 +34,10 @@ with
             , cast(generated_at as timestamp) as test_generated_at
             , metadata_hash
         from {{ source('raw_dbt_monitoring', 'dbt_tests') }}
+        qualify row_number() over(
+            partition by test_id
+            order by test_generated_at desc
+        ) = 1
     )
 
 select *


### PR DESCRIPTION
# Overview

This PR focuses on deduplicating three staging models that are impacting the corresponding dimension models. 

The duplication of IDs in these tables, as highlighted in the screenshot below, made this step necessary. Allowing duplicates to persist in both dimension and fact models could negatively affect downstream use cases, including reports and dashboards in data visualization tools.

![image](https://github.com/user-attachments/assets/38709872-09e0-4077-91d6-af96f83d15fc)
 
## Key changes

* add a qualify statement with a row_number in stg_elementary_dbt_models.sql
* add a qualify statement with a row_number in stg_elementary_dbt_sources.sql
* add a qualify statement with a row_number in stg_elementary_dbt_tests.sql