### PR TITLE
Patch/fix relationship test

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,6 +145,50 @@ qualify row_number() over (
 
 ```
 
+## Recommendations
+
+We strongly recommend that you use this package separatly from the production jobs. This is a way to prevent package-related issues from affecting your production jobs. 
+
+It has been observed that one possible issue with the package is related to its installation with the `dbt deps` command.
+
+A possible solution to this problem is just installing the package when the job that runs this package would be trigged. This ensures that althoug you've separeted the package from production jobs, the dbt deps command that will install all packages of your project don't beak anything in production.
+
+A possible way to do this is remain the packages.yml without the installation of the elementary_dbt_monitoring in your dbt project and have another yaml file in your dbt project folder, like `package_monitoring.yml`. So, the original yaml can be like this:
+
+```yml
+packages:
+  - package: dbt-labs/codegen
+    version: 0.12.1
+  - package: dbt-labs/dbt_utils
+    version: 1.1.1
+  ## Docs: https://docs.elementary-data.com
+  - package: elementary-data/elementary
+    version: 0.14.1
+  - package: calogica/dbt_expectations
+    version: 0.10.4
+
+```
+
+The monitoring package yaml can be like this:
+
+```yml
+    ## Dag Monitoring
+  - git: "https://github.com/techindicium/dbt-dag-monitoring.git"
+    revision: 0.21.1
+  ## Databricks Billing
+  - git: https://github.com/techindicium/dbt-databricks-billing
+    revision: 1.4.0
+  # Elementary dbt Monitoring
+  - git: https://github.com/techindicium/elementary-dbt-monitoring
+    revision: v2.1.0
+```
+
+And in your monitoring job you can run the following bash command before the `dbt deps`:
+
+```bash
+cat packages_monitoring.yml >> packages.yml
+```
+
 ## New releases
 
 Want a new release (major/minor/patch) ?

--- a/README.md
+++ b/README.md
@@ -151,7 +151,7 @@ We strongly recommend that you use this package separatly from the production jo
 
 It has been observed that one possible issue with the package is related to its installation with the `dbt deps` command.
 
-A possible solution to this problem is just installing the package when the job that runs this package would be trigged. This ensures that althoug you've separeted the package from production jobs, the dbt deps command that will install all packages of your project don't beak anything in production.
+A possible solution to this problem is just installing the package when the job that runs this package would be trigged. This ensures that although you've separeted the package from production jobs, the dbt deps command that will install all packages of your project don't beak anything in production.
 
 A possible way to do this is remain the packages.yml without the installation of the elementary_dbt_monitoring in your dbt project and have another yaml file in your dbt project folder, like `package_monitoring.yml`. So, the original yaml can be like this:
 
@@ -172,12 +172,6 @@ packages:
 The monitoring package yaml can be like this:
 
 ```yml
-    ## Dag Monitoring
-  - git: "https://github.com/techindicium/dbt-dag-monitoring.git"
-    revision: 0.21.1
-  ## Databricks Billing
-  - git: https://github.com/techindicium/dbt-databricks-billing
-    revision: 1.4.0
   # Elementary dbt Monitoring
   - git: https://github.com/techindicium/elementary-dbt-monitoring
     revision: v2.1.0

--- a/models/marts/fact_elementary_invocations.yml
+++ b/models/marts/fact_elementary_invocations.yml
@@ -34,7 +34,7 @@ models:
         description: "Column with the invocation date."
         tests:
           - relationships:
-              to: ref('dbt_utils_day')
+              to: ref('dbt_elementary_utils_day')
               field: date_day
 
       - name: 'dbt_invocation_command'

--- a/models/marts/fact_elementary_model_run_results.yml
+++ b/models/marts/fact_elementary_model_run_results.yml
@@ -28,7 +28,7 @@ models:
         description: "Column with the date the model was executed."
         tests:
           - relationships:
-              to: ref('dbt_utils_day')
+              to: ref('dbt_elementary_utils_day')
               field: date_day
               
       - name: 'invocation_status'

--- a/models/marts/fact_elementary_source_freshness.yml
+++ b/models/marts/fact_elementary_source_freshness.yml
@@ -34,7 +34,7 @@ models:
         description: "Column with the source creation date of the information in the dbt_source_freshness_results table."
         tests:
           - relationships:
-              to: ref('dbt_utils_day')
+              to: ref('dbt_elementary_utils_day')
               field: date_day
 
       - name: 'source_max_loaded_at_seconds'

--- a/models/marts/fact_elementary_test_run_results.yml
+++ b/models/marts/fact_elementary_test_run_results.yml
@@ -34,7 +34,7 @@ models:
         description: "Column with the timestamp of test detection."
         tests:
           - relationships:
-              to: ref('dbt_utils_day')
+              to: ref('dbt_elementary_utils_day')
               field: date_day
 
       - name: 'test_type'


### PR DESCRIPTION
#Overview

This PR aims to fix the relationship tests that ware referencing a wrong model. 

In previous releases, we´ve changed the name of dbt_utils_day due the fact that other monitoring packages makes use of this same name. So this can leverage some errors. 

But the last updates dind't change the name of the model in the tests itself.

Additionaly, we update the README with some recommendations of using the package.

## Key changes

* Updates in README
* changes dbt_utils_day to dbt_elementary_utils_day in relationships tests in fact_elementary_invocations, fact_elementary_model_run_results, fact_elementary_source_freschness and fact_elementary_test_run_results.